### PR TITLE
Introduce ability to log request identifier

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -671,6 +671,7 @@ class VatCalculator
 
     /**
      * @param $vatNumber
+     * @param $requestorVat
      *
      * @throws VATCheckUnavailableException
      *

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -690,8 +690,6 @@ class VatCalculator
         $requestorCountryCode = substr($requestorVat, 0, 2);
         $requestorVatNumber = substr($requestorVat, 2);
 
-        //dd('test' . $requestorVatNumber);
-
         $this->initSoapClient();
         $client = $this->soapClient;
         if ($client) {

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -264,7 +264,7 @@ class VatCalculator
         'FR' => [
             [
                 'postalCode' => '/^971\d{2,}$/',
-                'code'       => 'ES',
+                'code'       => 'FR',
                 'name'       => 'Guadeloupe',
             ],
             [
@@ -274,7 +274,7 @@ class VatCalculator
             ],
             [
                 'postalCode' => '/^973\d{2,}$/',
-                'code'       => 'ES',
+                'code'       => 'FR',
                 'name'       => 'Guyane',
             ],
             [
@@ -284,7 +284,7 @@ class VatCalculator
             ],
             [
                 'postalCode' => '/^976\d{2,}$/',
-                'code'       => 'ES',
+                'code'       => 'FR',
                 'name'       => 'Mayotte',
             ],
         ],

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -48,5 +48,17 @@ return [
     */
     'business_country_code' => '',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Business VAT number
+    |--------------------------------------------------------------------------
+    |
+    | If you want VIES to return a request identifier for logging purposes,
+    | you need to enter your VAT number here to have it included in the requests
+    | to the VIES validation service.
+    |
+    */
+    'business_vat_number' => '',
+
     'forward_soap_faults' => false,
 ];


### PR DESCRIPTION
This PR adds the feature I suggested in issue #76 

1/ We introduce a new config parameter that holds the business VAT number, in analogy with the already existing parameter business_country_code
2/ We migrate from calling the webservice checkVat to calling the service checkVatApprox. 
3/ since the contract is a bit different, for backwards compatibility (keeping the PR minor version change), we are explicitely adding name and address to the ressult in method getVatDetails

You can now call getVatDetails, and it will include requestIdentifier in the response.  This can be logged (together with request date) for legal purposes should the need arise.