### PR TITLE
Added functionality to support high and low tax rates in config file

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -623,7 +623,7 @@ class VatCalculator
         if (isset($this->config) && $this->config->has($taxKey)) {
             $config = $this->config->get($taxKey, 0);
 
-            if(! is_array($config)) {
+            if (! is_array($config)) {
                 return $config;
             }
 

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -621,7 +621,17 @@ class VatCalculator
         }
         $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
         if (isset($this->config) && $this->config->has($taxKey)) {
-            return $this->config->get($taxKey, 0);
+            $config = $this->config->get($taxKey, 0);
+
+            if(!is_array($config)){
+                return $config;
+            }
+
+            if ($type !== null && isset($config['rates'][$type])) {
+                return  $config['rates'][$type];
+            }
+
+            return isset($config['rate']) ? $config['rate'] : 0;
         }
 
         if (isset($this->postalCodeExceptions[$countryCode]) && $postalCode !== null) {

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -623,7 +623,7 @@ class VatCalculator
         if (isset($this->config) && $this->config->has($taxKey)) {
             $config = $this->config->get($taxKey, 0);
 
-            if(!is_array($config)){
+            if(! is_array($config)){
                 return $config;
             }
 

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -623,7 +623,7 @@ class VatCalculator
         if (isset($this->config) && $this->config->has($taxKey)) {
             $config = $this->config->get($taxKey, 0);
 
-            if(! is_array($config)){
+            if(! is_array($config)) {
                 return $config;
             }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -16,6 +16,8 @@ return [
 
     'rules' => [
         // 'XX' => 0.17,
+        // or
+        // 'XX' => [rate => 0.17, rates => ['high' => 0.50, 'low' => 0.07]]
     ],
 
     /*

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -129,7 +129,7 @@ class VatCalculatorTest extends TestCase
                 'rates' => [
                     'high' => 0.50,
                     'low' => 0.07,
-                ]
+                ],
             ]);
 
         $config->shouldReceive('has')


### PR DESCRIPTION
Added this functionality after seeing https://github.com/driesvints/vat-calculator/pull/49 - 
In Belgium, Germany and possibly other countries multiple tax rates apply, by allowing these tax rates to be set as an array in the config file we can set these manually if not added to the repo yet.