### PR TITLE
Fixing 404 errors with file get contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog follows [the Keep a Changelog standard](https://keepachangelog.com) (as of 2.4.2).
 
-## [Unreleased](https://github.com/mpociot/vat-calculator/compare/2.4.2...2.x)
+## [Unreleased](https://github.com/mpociot/vat-calculator/compare/2.4.2...main)
 
 
 ## [2.4.2 (2021-01-24)](https://github.com/mpociot/vat-calculator/compare/2.4.1...2.4.2)

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         }
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        },
         "laravel": {
             "providers": [
                 "Mpociot\\VatCalculator\\VatCalculatorServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "orchestra/testbench": "~3.5|^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.5"
     },
-    "suggest": {
-        "ext-curl": "Required when you need to validate UK VAT numbers."
-    },
     "autoload": {
         "classmap": [
             "src/controllers/Controller.php"

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -689,21 +689,21 @@ class VatCalculator
         $vatNumber = substr($vatNumber, 2);
 
         if (strtoupper($countryCode) === 'GB' && extension_loaded('curl')) {
-            $curl_handle = curl_init();
-            curl_setopt($curl_handle, CURLOPT_URL, "$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber");
-            curl_setopt($curl_handle, CURLOPT_CONNECTTIMEOUT, 2);
-            curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($curl_handle, CURLOPT_USERAGENT, 'VatCalculator');
-            $result = curl_exec($curl_handle);
-            curl_close($curl_handle);
+            $apiHeaders = get_headers("$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber");
+            $apiHeaders = explode(' ', $apiHeaders[0]);
+            $apiStatusCode = (int) $apiHeaders[1];
 
-            $response = json_decode($result, true, 512, JSON_OBJECT_AS_ARRAY);
-
-            if (isset($response['code'])) {
+            if ($apiStatusCode !== 200) {
                 return false;
             }
 
+            $response = json_decode(
+                file_get_contents("$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber"),
+                true
+            );
+
             return $response['target'];
+
         } else {
             $this->initSoapClient();
             $client = $this->soapClient;

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -703,7 +703,6 @@ class VatCalculator
             );
 
             return $response['target'];
-
         } else {
             $this->initSoapClient();
             $client = $this->soapClient;


### PR DESCRIPTION
Hi,

I just used get_headers to get the status code of the api, because it was throwing an uncatchable 404 error when using file_get_contents and the vat number wasnt a valid one.

Now it should work without the need for the cURL extension aswell.

Thank you

PS: Seems something went wrong last time... New try...