### PR TITLE
Using get_headers to avoid 404 status code with file_get_contents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "orchestra/testbench": "~3.5|^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.5"
     },
-    "suggest": {
-        "ext-curl": "Required when you need to validate UK VAT numbers."
-    },
     "autoload": {
         "classmap": [
             "src/controllers/Controller.php"

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -688,7 +688,7 @@ class VatCalculator
         $countryCode = substr($vatNumber, 0, 2);
         $vatNumber = substr($vatNumber, 2);
 
-        if (strtoupper($countryCode) === 'GB' && extension_loaded('curl')) {
+        if (strtoupper($countryCode) === 'GB') {
             $apiHeaders = get_headers("$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber");
             $apiHeaders = explode(' ', $apiHeaders[0]);
             $apiStatusCode = (int) $apiHeaders[1];

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -689,21 +689,18 @@ class VatCalculator
         $vatNumber = substr($vatNumber, 2);
 
         if (strtoupper($countryCode) === 'GB' && extension_loaded('curl')) {
-            $curl_handle = curl_init();
-            curl_setopt($curl_handle, CURLOPT_URL, "$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber");
-            curl_setopt($curl_handle, CURLOPT_CONNECTTIMEOUT, 2);
-            curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($curl_handle, CURLOPT_USERAGENT, 'VatCalculator');
-            $result = curl_exec($curl_handle);
-            curl_close($curl_handle);
+            $apiHeaders = get_headers("$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber");
+            $apiHeaders = explode(' ', $apiHeaders[0]);
+            $apiStatusCode = (int) $apiHeaders[1];
 
-            $response = json_decode($result, true, 512, JSON_OBJECT_AS_ARRAY);
-
-            if (isset($response['code'])) {
+            if ($apiStatusCode !== 200) {
                 return false;
             }
 
-            return $response['target'];
+            $apiResponse = file_get_contents("$this->ukValidationEndpoint/organisations/vat/check-vat-number/lookup/$vatNumber");
+            $apiResponse = json_decode($apiResponse, true);
+
+            return $apiResponse['target'];
         } else {
             $this->initSoapClient();
             $client = $this->soapClient;


### PR DESCRIPTION
Hi,

I just used get_headers to get the status code of the api, because it was throwing an uncatchable 404 error when using file_get_contents and the vat number wasnt a valid one.

Now it should work without the need for the cURL extension aswell.

Thank you

PS: Hope this time, there is no problem...