### PR TITLE
Introduce VIES requester information enabling ability to log request identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,37 @@ try {
 }
 ```
 
+#### Logging VIES request identifiers
+
+VIES allows you to include your own VAT number to be identified as the requester of the VIES request.
+In such cases, VIES will log your request, and assign the request a requestIdentifier which you may log into your database as proof of your consultation.
+In order to do so, you may pass your own businesses VAT number as the second parameter to the `getVATDetails` method:
+
+```php
+try {
+    $vat_details = VatCalculator::getVATDetails('NL 123456789 B01', 'BE 0123456789');
+    print_r($vat_details);
+    /* Outputs
+    stdClass Object
+    (
+        [countryCode] => NL
+        [vatNumber] => 123456789B01
+        [requestDate] => 2017-04-06+02:00
+        [valid] => false
+        [name] => Name of the company
+        [address] => Address of the company
+        [requestIdentifier] => WAPIAAAAXogiZNof
+        [requesterCountryCode] => BE
+        [requesterVatNumber] => 0123456789
+    )
+    */
+} catch( VATCheckUnavailableException $e ){
+    // Please handle me
+}
+```
+
+The returned requestIdentifier can then be logged in your database to serve as proof of your consultation.
+
 #### UK VAT Numbers
 
 UK VAT numbers are formatted a little differently:

--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -381,6 +381,10 @@ class VatCalculator
      * @var string
      */
     protected $businessCountryCode;
+    /**
+     * @var string
+     */
+    protected $businessVatNumber;
 
     /**
      * @var string
@@ -398,6 +402,13 @@ class VatCalculator
         if (isset($this->config) && $this->config->has($businessCountryKey)) {
             $this->setBusinessCountryCode($this->config->get($businessCountryKey, ''));
         }
+
+        $businessVatNumberKey = 'vat_calculator.business_vat_number';
+        if (isset($this->config) && $this->config->has($businessVatNumberKey)) {
+            $this->setBusinessVatNumber($this->config->get($businessVatNumberKey, null));
+        }
+
+
     }
 
     /**
@@ -593,6 +604,14 @@ class VatCalculator
     }
 
     /**
+     * @param string $businessVatNumber
+     */
+    public function setBusinessVatNumber($businessVatNumber)
+    {
+        $this->businessVatNumber = $businessVatNumber;
+    }
+
+    /**
      * Returns the tax rate for the given country code.
      * This method is used to allow backwards compatibility.
      *
@@ -713,7 +732,7 @@ class VatCalculator
             if ($client) {
                 try {
                     // include requester information when provided
-                    $requesterVatNumber = $requesterVatNumber ?: config('vat_calculator.business_vat_number');
+                    $requesterVatNumber = $requesterVatNumber ?: $this->businessVatNumber;
                     if(!is_null($requesterVatNumber)) {
                         $requesterVatNumber = str_replace([' ', "\xC2\xA0", "\xA0", '-', '.', ','], '', trim($requesterVatNumber));
                         $viesResponse = $client->checkVatApprox([

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -45,6 +45,27 @@ return [
 
     'business_country_code' => '',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Business vat number
+    |--------------------------------------------------------------------------
+    |
+    | This should be the VAT number of your business.
+    | It is used to identify your business as the requester for any calls made
+    | to the VIES validation service to fetch the VAT details of any given
+    | VAT number, at which time VIES will return a requestIdentifier you can
+    | log in your database which may serve as proof of your consultation should
+    | your VAT administration ever request it.
+    |
+    | Please note: when you enter an invalid VAT number here, VIES validation service
+    | will throw an exception and you will not be able to validate any VAT number.
+    |
+    | Setting value to null will disable the option.
+    |
+    */
+
+    'business_vat_number' => null,
+
     'forward_soap_faults' => false,
 
 ];


### PR DESCRIPTION
EU businesses are required to validate the VAT numbers for their customers.
To enable consumers of the VIES validation service to store a proof of consulting the VIES register, VIES can return a requestIdentifier which can then be stored by the consumer of the service as a proof of consultation for a given VAT number.

This request identifier can be used whenever there is a question raised by your VAT administration.

In order to be able to get the requestIdentifier from VIES, we need to:

- provide information regarding the requester to VIES validation
- call the soap operation `checkVatApprox` instead of `checkVat`

This PR introduces the ability to do just that:

- `VatCalculator::getVatDetails` now accepts an optional second parameter `requesterVatNumber`
- The method now calls soap operation `checkVatApprox`
- Laravel users can define the `businessVatNumber` in the publishable config file

Please note: the response of the `checkVatApprox` operation is somewhat different from the `checkVat` response; to ensure backwards compatibility, we are copying the `response->traderName` and 'response->traderAddress` to `response->name` and `response->address` respectively

I do apologise for not including tests, but I've had issues getting them up and running.  I tested the changes though, but maybe you can add additional test cases if you want to.

Thank you for considering this PR!