### PR TITLE
Use arr helper as fix for array->has() error

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -3,6 +3,7 @@
 namespace Mpociot\VatCalculator;
 
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Arr;
 use Mpociot\VatCalculator\Exceptions\VATCheckUnavailableException;
 use SoapClient;
 use SoapFault;
@@ -395,8 +396,9 @@ class VatCalculator
         $this->config = $config;
 
         $businessCountryKey = 'vat_calculator.business_country_code';
-        if (isset($this->config) && $this->config->has($businessCountryKey)) {
-            $this->setBusinessCountryCode($this->config->get($businessCountryKey, ''));
+
+        if (isset($this->config) && Arr::has($this->config, $businessCountryKey)) {
+            $this->setBusinessCountryCode(Arr::get($this->config, $businessCountryKey, ''));
         }
     }
 
@@ -454,7 +456,7 @@ class VatCalculator
     {
         $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
 
-        return isset($this->taxRules[strtoupper($countryCode)]) || (isset($this->config) && $this->config->has($taxKey));
+        return isset($this->taxRules[strtoupper($countryCode)]) || (isset($this->config) && Arr::has($this->config, $taxKey));
     }
 
     /**
@@ -625,8 +627,8 @@ class VatCalculator
             return 0;
         }
         $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
-        if (isset($this->config) && $this->config->has($taxKey)) {
-            return $this->config->get($taxKey, 0);
+        if (isset($this->config) && Arr::has($this->config, $taxKey)) {
+            return Arr::get($this->config, $taxKey, 0);
         }
 
         if (isset($this->postalCodeExceptions[$countryCode]) && $postalCode !== null) {


### PR DESCRIPTION
An error occured on VatCalculator.php:

Call to a member function has() on array

Using the Illuminate\Support\Arr helper solved this issue, ie:

Arr::has($this->config, $businessCountryKey)