### PR TITLE
Correct VAT and postal code for Campione d'Italia

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -105,7 +105,7 @@ class VatCalculator
         'IT' => [ // Italy
             'rate' => 0.22,
             'exceptions' => [
-                'Campione d\'Italia' => 0,
+                'Campione d\'Italia' => 0.077,
                 'Livigno' => 0,
             ],
         ],
@@ -193,11 +193,6 @@ class VatCalculator
                 'postalCode' => '/^8238$/',
                 'code' => 'DE',
                 'name' => 'Büsingen am Hochrhein',
-            ],
-            [
-                'postalCode' => '/^6911$/',
-                'code' => 'IT',
-                'name' => "Campione d'Italia",
             ],
             // The Italian city of Domodossola has a Swiss post office also
             [


### PR DESCRIPTION
After checking the changes in #137 I've noticed that Campione d'Italia became part of the EU customs territory on 1 Jan 2020.

That means two relevant changes:
- VAT will apply, but the tax rate will remain that of Switzerland:
  - https://en.wikipedia.org/w/index.php?title=Campione_d%27Italia&diff=prev&oldid=937493207
  - https://www.europeansources.info/record/directive-eu-2019-475-amending-directives-2006-112-ec-and-2008-118-ec-as-regards-the-inclusion-of-the-italian-municipality-of-campione-ditalia-and-the-italian-waters-of-lake-lugano-in-the-c/
  - https://www.euronews.com/2020/01/03/tiny-italian-enclave-in-switzerland-transferred-back-to-italy-and-the-eu-s-customs-union
Unfortunately, this package doesn't support high/low rates for exceptions, so I put just the higher one, like in the other exceptions.

- The Swiss postal code ceased to be valid:
> Until 2020, mail could be sent to Campione using either a Swiss postal code (CH-6911) or an Italian one (I-22061) via Switzerland or Italy, but the Swiss postal code ceased to be valid, with mail instead being charged at the same international rate as that between Switzerland and Italy.
https://en.wikipedia.org/w/index.php?title=Campione_d%27Italia&diff=prev&oldid=957716786
