### PR TITLE
Added isValidVatNumberFormat + connection_timeout for the SOAP Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ return [
 ];
 ```
 
+You can also set a timeout for the SOAP client. By default, SOAP aborts the request to VIES after 30 seconds. If you do not want to wait that long, you can reduce the timeout, for example to 10 seconds:
+
+```php
+<?php
+
+return [
+    'soap_timeout' => 10,
+];
+```
+
 ### ValidVatNumber Validation Rule
 
 VatCalculator also ships with a `ValidVatNumber` validation rule for VAT Numbers. You can use this when validation input from a form request or a standalone validator instance:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ try {
 }
 ```
 
+Alternatively, it is also possible to validate only the format of the VAT Number specified by [VIES](http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11). Useful if you do not want to wait for a response from the SOAP API.
+
+```php
+    $validVAT = VatCalculator::isValidVATNumber('NL 123456789 B01'); // false 
+    $validVAT = VatCalculator::isValidVatNumberFormat('NL 123456789 B01'); // true (format is correct)
+```
+
 ### Get EU VAT number details
 
 To get the details of a VAT number, you can use the `getVATDetails` method. The VAT number should be in a format specified by the [VIES](http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11). The given VAT numbers will be truncated and non relevant characters / whitespace will automatically be removed.

--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ try {
 }
 ```
 
-Alternatively, it is also possible to validate only the format of the VAT Number specified by [VIES](http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11). Useful if you do not want to wait for a response from the SOAP API.
+Alternatively, it is also possible to validate only the format of the VAT Number specified by [VIES](http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11). This is useful, if you do not want to wait for a response from the SOAP API.
 
 ```php
-    $validVAT = VatCalculator::isValidVATNumber('NL 123456789 B01'); // false 
-    $validVAT = VatCalculator::isValidVatNumberFormat('NL 123456789 B01'); // true (format is correct)
+// This check will return false because no connection to VIES could be made...
+$validVAT = VatCalculator::isValidVATNumber('NL 123456789 B01');
+
+// This check will return true because only the format is checked...
+$validVAT = VatCalculator::isValidVatNumberFormat('NL 123456789 B01');
 ```
 
 ### Get EU VAT number details

--- a/config/vat_calculator.php
+++ b/config/vat_calculator.php
@@ -44,4 +44,17 @@ return [
 
     'forward_soap_faults' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Change the SOAP timeout
+    |--------------------------------------------------------------------------
+    |
+    | By default, SOAP aborts the request to VIES after 30 seconds.
+    | If you do not want to wait that long, you can reduce the timeout.
+    | Timeout is in seconds and integer.
+    |
+    */
+
+    'soap_timeout' => 30,
+
 ];

--- a/config/vat_calculator.php
+++ b/config/vat_calculator.php
@@ -51,7 +51,7 @@ return [
     |
     | By default, SOAP aborts the request to VIES after 30 seconds.
     | If you do not want to wait that long, you can reduce the timeout.
-    | Timeout is in seconds and integer.
+    | The timeout is specified in seconds.
     |
     */
 

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -751,8 +751,10 @@ class VatCalculator
             $timeout = $this->config->get('vat_calculator.soap_timeout');
         }
 
+        $context = stream_context_create(['http' => ['timeout' => $timeout]]);
+
         try {
-            $this->soapClient = new SoapClient(self::VAT_SERVICE_URL, ['connection_timeout' => $timeout]);
+            $this->soapClient = new SoapClient(self::VAT_SERVICE_URL, ['stream_context' => $context]);
         } catch (SoapFault $e) {
             if (isset($this->config) && $this->config->get('vat_calculator.forward_soap_faults')) {
                 throw new VATCheckUnavailableException($e->getMessage(), $e->getCode(), $e->getPrevious());

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -320,6 +320,43 @@ class VatCalculator
     ];
 
     /**
+     * Regular expression patterns per country code for VAT
+     *
+     * @var array
+     * @link https://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
+     */
+    protected $patterns = [
+        'AT' => 'U[A-Z\d]{8}',
+        'BE' => '(0\d{9}|\d{10})',
+        'BG' => '\d{9,10}',
+        'CY' => '\d{8}[A-Z]',
+        'CZ' => '\d{8,10}',
+        'DE' => '\d{9}',
+        'DK' => '(\d{2} ?){3}\d{2}',
+        'EE' => '\d{9}',
+        'EL' => '\d{9}',
+        'ES' => '([A-Z]\d{7}[A-Z]|\d{8}[A-Z]|[A-Z]\d{8})',
+        'FI' => '\d{8}',
+        'FR' => '[A-Z\d]{2}\d{9}',
+        'GB' => '(\d{9}|\d{12}|(GD|HA)\d{3})',
+        'HR' => '\d{11}',
+        'HU' => '\d{8}',
+        'IE' => '([A-Z\d]{8}|[A-Z\d]{9})',
+        'IT' => '\d{11}',
+        'LT' => '(\d{9}|\d{12})',
+        'LU' => '\d{8}',
+        'LV' => '\d{11}',
+        'MT' => '\d{8}',
+        'NL' => '\d{9}B\d{2}',
+        'PL' => '\d{10}',
+        'PT' => '\d{9}',
+        'RO' => '\d{2,10}',
+        'SE' => '\d{12}',
+        'SI' => '\d{8}',
+        'SK' => '\d{10}'
+    ];
+
+    /**
      * @var float
      */
     protected $netPrice = 0.0;
@@ -393,7 +430,7 @@ class VatCalculator
      */
     public function shouldCollectVAT($countryCode)
     {
-        $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
+        $taxKey = 'vat_calculator.rules.' . strtoupper($countryCode);
 
         return isset($this->taxRules[strtoupper($countryCode)]) || (isset($this->config) && $this->config->has($taxKey));
     }
@@ -567,7 +604,7 @@ class VatCalculator
             return 0;
         }
 
-        $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
+        $taxKey = 'vat_calculator.rules.' . strtoupper($countryCode);
 
         if (isset($this->config) && $this->config->has($taxKey)) {
             return $this->config->get($taxKey, 0);
@@ -575,7 +612,7 @@ class VatCalculator
 
         if (isset($this->postalCodeExceptions[$countryCode]) && $postalCode) {
             foreach ($this->postalCodeExceptions[$countryCode] as $postalCodeException) {
-                if (! preg_match($postalCodeException['postalCode'], $postalCode)) {
+                if (!preg_match($postalCodeException['postalCode'], $postalCode)) {
                     continue;
                 }
 
@@ -600,6 +637,31 @@ class VatCalculator
     public function getTaxValue()
     {
         return $this->taxValue;
+    }
+
+    /**
+     * Validate a VAT number format. This does not check whether the VAT number was really issued.
+     *
+     * @param string $vatNumber
+     *
+     * @return bool
+     */
+    public function isValidVatNumberFormat($vatNumber)
+    {
+        $vatNumber = str_replace([' ', "\xC2\xA0", "\xA0", '-', '.', ','], '', trim($vatNumber));
+
+        if ($vatNumber === '') {
+            return false;
+        }
+
+        $countryCode = substr($vatNumber, 0, 2);
+        $vatNumber = substr($vatNumber, 2);
+
+        if (!isset($this->patterns[$countryCode])) {
+            return false;
+        }
+
+        return preg_match('/^' . $this->patterns[$countryCode] . '$/', $vatNumber) > 0;
     }
 
     /**

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -612,7 +612,7 @@ class VatCalculator
 
         if (isset($this->postalCodeExceptions[$countryCode]) && $postalCode) {
             foreach ($this->postalCodeExceptions[$countryCode] as $postalCodeException) {
-                if (!preg_match($postalCodeException['postalCode'], $postalCode)) {
+                if (! preg_match($postalCodeException['postalCode'], $postalCode)) {
                     continue;
                 }
 
@@ -640,10 +640,9 @@ class VatCalculator
     }
 
     /**
-     * Validate a VAT number format. This does not check whether the VAT number was really issued.
+     * Validate a VAT number format without checking if the VAT number was really issued.
      *
-     * @param string $vatNumber
-     *
+     * @param  string  $vatNumber
      * @return bool
      */
     public function isValidVatNumberFormat($vatNumber)

--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -744,8 +744,15 @@ class VatCalculator
             return;
         }
 
+        // Set's default timeout time.
+        $timeout = 30;
+
+        if (isset($this->config) && $this->config->has('vat_calculator.soap_timeout')) {
+            $timeout = $this->config->get('vat_calculator.soap_timeout');
+        }
+
         try {
-            $this->soapClient = new SoapClient(self::VAT_SERVICE_URL);
+            $this->soapClient = new SoapClient(self::VAT_SERVICE_URL, ['connection_timeout' => $timeout]);
         } catch (SoapFault $e) {
             if (isset($this->config) && $this->config->get('vat_calculator.forward_soap_faults')) {
                 throw new VATCheckUnavailableException($e->getMessage(), $e->getCode(), $e->getPrevious());

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -90,7 +90,7 @@ class VatCalculatorTest extends TestCase
         $net = 24.00;
         $countryCode = 'DE';
 
-        $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
+        $taxKey = 'vat_calculator.rules.' . strtoupper($countryCode);
 
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
@@ -123,12 +123,12 @@ class VatCalculatorTest extends TestCase
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode, 0)
+            ->with('vat_calculator.rules.' . $countryCode, 0)
             ->andReturn(0.19);
 
         $config->shouldReceive('has')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode)
+            ->with('vat_calculator.rules.' . $countryCode)
             ->andReturn(true);
 
         $config->shouldReceive('has')
@@ -163,12 +163,12 @@ class VatCalculatorTest extends TestCase
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode, 0)
+            ->with('vat_calculator.rules.' . $countryCode, 0)
             ->andReturn(0.19);
 
         $config->shouldReceive('has')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode)
+            ->with('vat_calculator.rules.' . $countryCode)
             ->andReturn(true);
 
         $config->shouldReceive('has')
@@ -263,12 +263,12 @@ class VatCalculatorTest extends TestCase
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode, 0)
+            ->with('vat_calculator.rules.' . $countryCode, 0)
             ->andReturn(0.19);
 
         $config->shouldReceive('has')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode)
+            ->with('vat_calculator.rules.' . $countryCode)
             ->andReturn(true);
 
         $config->shouldReceive('has')
@@ -288,12 +288,12 @@ class VatCalculatorTest extends TestCase
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode, 0)
+            ->with('vat_calculator.rules.' . $countryCode, 0)
             ->andReturn(0.19);
 
         $config->shouldReceive('has')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode)
+            ->with('vat_calculator.rules.' . $countryCode)
             ->andReturn(true);
 
         $config->shouldReceive('has')
@@ -356,7 +356,7 @@ class VatCalculatorTest extends TestCase
         $result = new \stdClass();
         $result->valid = true;
 
-        $vatCheck = $this->getMockFromWsdl(__DIR__.'/checkVatService.wsdl', 'VATService');
+        $vatCheck = $this->getMockFromWsdl(__DIR__ . '/checkVatService.wsdl', 'VATService');
         $vatCheck->expects($this->any())
             ->method('checkVat')
             ->with([
@@ -377,7 +377,7 @@ class VatCalculatorTest extends TestCase
         $result = new \stdClass();
         $result->valid = false;
 
-        $vatCheck = $this->getMockFromWsdl(__DIR__.'/checkVatService.wsdl', 'VATService');
+        $vatCheck = $this->getMockFromWsdl(__DIR__ . '/checkVatService.wsdl', 'VATService');
         $vatCheck->expects($this->any())
             ->method('checkVat')
             ->with([
@@ -395,7 +395,7 @@ class VatCalculatorTest extends TestCase
 
     public function testValidateVATNumberReturnsFalseOnSoapFailure()
     {
-        $vatCheck = $this->getMockFromWsdl(__DIR__.'/checkVatService.wsdl', 'VATService');
+        $vatCheck = $this->getMockFromWsdl(__DIR__ . '/checkVatService.wsdl', 'VATService');
         $vatCheck->expects($this->any())
             ->method('checkVat')
             ->with([
@@ -413,7 +413,7 @@ class VatCalculatorTest extends TestCase
 
     public function testValidateVATNumberReturnsFalseOnSoapFailureWithoutForwarding()
     {
-        $vatCheck = $this->getMockFromWsdl(__DIR__.'/checkVatService.wsdl', 'VATService');
+        $vatCheck = $this->getMockFromWsdl(__DIR__ . '/checkVatService.wsdl', 'VATService');
         $vatCheck->expects($this->any())
             ->method('checkVat')
             ->with([
@@ -443,7 +443,7 @@ class VatCalculatorTest extends TestCase
     {
         $this->expectException(\Mpociot\VatCalculator\Exceptions\VATCheckUnavailableException::class);
 
-        $vatCheck = $this->getMockFromWsdl(__DIR__.'/checkVatService.wsdl', 'VATService');
+        $vatCheck = $this->getMockFromWsdl(__DIR__ . '/checkVatService.wsdl', 'VATService');
         $vatCheck->expects($this->any())
             ->method('checkVat')
             ->with([
@@ -649,7 +649,7 @@ class VatCalculatorTest extends TestCase
     public function testShouldCollectVATFromConfig()
     {
         $countryCode = 'TEST';
-        $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
+        $taxKey = 'vat_calculator.rules.' . strtoupper($countryCode);
 
         $config = m::mock('Illuminate\Contracts\Config\Repository');
 
@@ -739,7 +739,7 @@ class VatCalculatorTest extends TestCase
         $gross = 36.00;
         $countryCode = 'DE';
 
-        $taxKey = 'vat_calculator.rules.'.strtoupper($countryCode);
+        $taxKey = 'vat_calculator.rules.' . strtoupper($countryCode);
 
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
@@ -772,12 +772,12 @@ class VatCalculatorTest extends TestCase
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode, 0)
+            ->with('vat_calculator.rules.' . $countryCode, 0)
             ->andReturn(0.19);
 
         $config->shouldReceive('has')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode)
+            ->with('vat_calculator.rules.' . $countryCode)
             ->andReturn(true);
 
         $config->shouldReceive('has')
@@ -813,12 +813,12 @@ class VatCalculatorTest extends TestCase
         $config = m::mock('Illuminate\Contracts\Config\Repository');
         $config->shouldReceive('get')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode, 0)
+            ->with('vat_calculator.rules.' . $countryCode, 0)
             ->andReturn(0.19);
 
         $config->shouldReceive('has')
             ->once()
-            ->with('vat_calculator.rules.'.$countryCode)
+            ->with('vat_calculator.rules.' . $countryCode)
             ->andReturn(true);
 
         $config->shouldReceive('has')
@@ -932,5 +932,108 @@ class VatCalculatorTest extends TestCase
         $result = $vatCalculator->calculate($gross, $countryCode, $postalCode, $company, $type);
 
         $this->assertEquals(26.16, $result);
+    }
+
+    /**
+     * @covers VatCalculator::isValidVatNumberFormat
+     */
+    public function testIsValidVatNumberFormat()
+    {
+        $valid = [
+            'ATU12345678',
+            'BE0123456789',
+            'BE1234567891',
+            'BG123456789',
+            'BG1234567890',
+            'CY12345678X',
+            'CZ12345678',
+            'DE123456789',
+            'DE 190 098 891',
+            'DK12345678',
+            'DK99 99 99 99',
+            'EE123456789',
+            'EL123456789',
+            'ESX12345678',
+            'FI12345678',
+            'FR12345678901',
+            'FRA2345678901',
+            'FRAB345678901',
+            'FR1B345678901',
+            'GB999999973',
+            'HU12345678',
+            'HR12345678901',
+            'IE1234567X',
+            'IT12345678901',
+            'LT123456789',
+            'LU12345678',
+            'LV12345678901',
+            'MT12345678',
+            'NL123456789B12',
+            'NL 123456789 B01',
+            'PL1234567890',
+            'PT123456789',
+            'RO123456789',
+            'SE123456789012',
+            'SI12345678',
+            'SK1234567890',
+        ];
+
+        $vatCalculator = new VatCalculator();
+        foreach ($valid as $format) {
+            $this->assertTrue($vatCalculator->isValidVatNumberFormat($format), "{$format} did not pass validation.");
+        }
+
+        $invalid = [
+            '',
+            'ATU1234567',
+            'BE012345678',
+            'BE123456789',
+            'BG1234567',
+            'CY1234567X',
+            'CZ1234567',
+            'DE12345678',
+            'DK1234567',
+            'EE12345678',
+            'EL12345678',
+            'ESX1234567',
+            'FI1234567',
+            'FR1234567890',
+            'GB99999997',
+            'HU1234567',
+            'HR1234567890',
+            'IE123456X',
+            'IT1234567890',
+            'LT12345678',
+            'LU1234567',
+            'LV1234567890',
+            'MT1234567',
+            'NL12345678B12',
+            'PL123456789',
+            'PT12345678',
+            'RO1',  // Romania has a really weird VAT format...
+            'SE12345678901',
+            'SI1234567',
+            'SK123456789',
+
+            // valid number but with prefix
+            'invalid_prefix_GB999999973',
+            'invalid_prefix_IE1234567X',
+            'invalid_prefix_ESB1234567C',
+            'invalid_prefix_BE0123456789',
+            'invalid_prefix_MT12345678',
+            'invalid_prefix_LT123456789',
+
+            // valid number but with suffix
+            'IE1234567X_invalid_suffix',
+            'ESB1234567C_invalid_suffix',
+            'BE0123456789_invalid_suffix',
+            'MT12345678_invalid_suffix',
+            'LT123456789_invalid_suffix',
+        ];
+
+        foreach ($invalid as $format) {
+            $isValid = $vatCalculator->isValidVatNumberFormat($format);
+            $this->assertFalse($isValid, "{$format} passed validation, but shouldn't.");
+        }
     }
 }


### PR DESCRIPTION
#142
#36

I have added the function `isValidVatNumberFormat` to validate the formating of the VAT number based on [VIES](http://ec.europa.eu/taxation_customs/vies/faqvies.do#item_11). 

Besides that, I have added an option to the config file, to change the `connection_timeout`of the SOAP client. It's called `soap_timeout` in the config file. Its default value is 30 seconds.

Three questions came into my mind:

1. When validating the formate, I have used your code to "clean up" the VAT number: 

`$vatNumber = str_replace([' ', "\xC2\xA0", "\xA0", '-', '.', ','], '', trim($vatNumber));`

The question is. Why should I replace empty space? As it is officially okay to use it, according to VIES. Obviously, we should trim it. But why should we remove the rest? If the patterns do not match the VAT number string, we just say it's the wrong format.

2. I have set the `soap_timeout` to 30 seconds. Is this a good default value?
3. I have used some code from another package. How do you give credits in the comments block? (Not sure how it's done usually)

Thanks for letting me contribute :)