### PR TITLE
Starting 2024, CZ has just one low rate 12%

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -69,8 +69,7 @@ class VatCalculator
             'rate' => 0.21,
             'rates' => [
                 'high' => 0.21,
-                'low' => 0.10,
-                'low1' => 0.15,
+                'low' => 0.12,
             ],
         ],
         'DE' => [ // Germany


### PR DESCRIPTION
Note: merge in 2024
~~Note 2: the change has to be signed by the president yet, I'll update the PR once that's done~~ signed see below

Source for example here

"The basic VAT rate will remain at 21 percent.  The reduced rate will be 12 percent (so far we have two reduced rates: 10 and 15 percent).  There will be zero tax on books."

Originally: "Základní sazba DPH zůstane 21 procent. Snížená sazba bude nově 12 procent (dosud máme dvě snížené sazby: 10 a 15 procent). Na knihy bude nově nulová daň."  https://www.penize.cz/dph/442212-zmeny-dph-prehledne-kompletni-seznam

Another source:
"The consolidation package introduces only two VAT rates, namely 12 and 21 percent." Originally: "Konsolidační balíček zavádí pouze dvě sazby DPH, a to 12 a 21 procent." https://www.e15.cz/konsolidacni-balicek-vlady-2023-obsah