### PR TITLE
Update Swiss VAT rates for 2024

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -306,12 +306,12 @@ class VatCalculator
         ],
 
         // Non-EU with their own VAT requirements -- https://www.estv.admin.ch/estv/en/home/value-added-tax/vat-rates-switzerland.html
-        'CH' => [ // Switzerland -- INFO: ON 01.01.2024 VAT RATES CHANGE IN CH
-            'rate' => 0.077,
+        'CH' => [ // Switzerland
+            'rate' => 0.081,
             'rates' => [
-                'high' => 0.077,
-                'low' => 0.025,
-                'super-reduced' => 0.037,
+                'high' => 0.081,
+                'low' => 0.026,
+                'super-reduced' => 0.038,
             ],
         ],
     ];


### PR DESCRIPTION
From 1 January 2024, the following current VAT rates apply in Switzerland:

Normal rate: 8,1 %
Reduced rate: 2,6 %
Special rate for accommodation: 3,8 %

Reason for the increase in tax rates:
In the vote of 25 September 2022, the amendment to the AHV Act and the federal decree on the supplementary financing of the AHV were accepted.

https://www.estv.admin.ch/estv/en/home/value-added-tax/vat-rates-switzerland.html