### PR TITLE
Update VAT rate for Azores to 16%

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -246,7 +246,7 @@ class VatCalculator
         'PT' => [ // Portugal
             'rate' => 0.23,
             'exceptions' => [
-                'Azores' => 0.18,
+                'Azores' => 0.16,
                 'Madeira' => 0.22,
             ],
             'rates' => [


### PR DESCRIPTION
"a standard rate of 23% in mainland Portugal, 16% in the Autonomous Region of the Azores" https://eportugal.gov.pt/en/cidadaos-europeus-viajar-viver-e-fazer-negocios-em-portugal/impostos-para-atividades-economicas-em-portugal/imposto-sobre-valor-acrescentado-iva-em-portugal