### PR TITLE
Reduced rate and parking rate corrected for Belgium

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -45,9 +45,9 @@ class VatCalculator
             'rate' => 0.21,
             'rates' => [
                 'high' => 0.21,
-                'low' => 0.09,
+                'low' => 0.06,
                 'low1' => 0.12,
-                'parking' => 0.0012,
+                'parking' => 0.12,
             ],
         ],
         'BG' => [ // Bulgaria


### PR DESCRIPTION
The low rate is 6% and parking rate should be 12% same as intermediate rate.
See https://finance.belgium.be/en/enterprises/vat/vat-obligation/rates-and-calculation/vat-rates#q1