### PR TITLE
Update postal code exceptions for Portugal

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -449,12 +449,12 @@ class VatCalculator
         ],
         'PT' => [
             [
-                'postalCode' => '/^9[0-4]\d{2,}$/',
+                'postalCode' => '/^9[0-4]\d{2,}(?:-\d+)*$/',
                 'code' => 'PT',
                 'name' => 'Madeira',
             ],
             [
-                'postalCode' => '/^9[5-9]\d{2,}$/',
+                'postalCode' => '/^9[5-9]\d{2,}(?:-\d+)*$/',
                 'code' => 'PT',
                 'name' => 'Azores',
             ],

--- a/tests/VatCalculatorTest.php
+++ b/tests/VatCalculatorTest.php
@@ -540,6 +540,12 @@ class VatCalculatorTest extends TestCase
         $this->assertEquals(29.28, $result);
         $this->assertEquals(0.22, $vatCalculator->getTaxRate());
         $this->assertEquals(5.28, $vatCalculator->getTaxValue());
+
+        $postalCode = '9500-339'; // Azores
+        $result = $vatCalculator->calculate($net, 'PT', $postalCode, false);
+        $this->assertEquals(27.84, $result);
+        $this->assertEquals(0.16, $vatCalculator->getTaxRate());
+        $this->assertEquals(3.84, $vatCalculator->getTaxValue());
     }
 
     public function testPostalCodesWithoutExceptionsGetStandardRate()


### PR DESCRIPTION
A full postal code for the Azores is `9[5-9]xx-xxx` but the regex never matches this format since it only looks for numbers.

This PR fixes this issue, for both the Azores and Madeira. It makes `9500` trigger the exception, as well as `9500-339`.

I also noticed the current regex allowed `950000000....` (with unlimited digits). It seems to be useless since Portuguese postal codes are only 4 digits before the hyphen, but I kept this behavior in order to avoid an undesirable breaking change. So `95012341234-339` will match too.