### PR TITLE
Update Finland rates

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -121,9 +121,9 @@ class VatCalculator
             ],
         ],
         'FI' => [ // Finland
-            'rate' => 0.24,
+            'rate' => 0.255,
             'rates' => [
-                'high' => 0.24,
+                'high' => 0.255,
                 'low' => 0.10,
                 'low1' => 0.14,
             ],


### PR DESCRIPTION
Finland VAT rise to 25.5% on 1 September 2024

https://www.vatcalc.com/finland/finland-increases-vat-to-24-january-2013/