### PR TITLE
Update Estonia's main VAT rate to 24%

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -89,9 +89,9 @@ class VatCalculator
             ],
         ],
         'EE' => [ // Estonia
-            'rate' => 0.22,
+            'rate' => 0.24,
             'rates' => [
-                'high' => 0.22,
+                'high' => 0.24,
                 'low' => 0.09,
             ],
         ],


### PR DESCRIPTION
Per https://marosavat.com/estonia-increase-vat-rate-2025/ - this WILL apply from July 1st 2025.

They also mention an increase per January 1st of the accomodations services (9 to 13%) and books (5 to 9%). I am not sure what the low rate refers to here so I left it alone, but anyway this should be changed in another PR if it needs changing, as this is already effective, and this PR should be held until July 1st.