### PR TITLE
Update Romania's main VAT to 21%, low to 11%

### DIFF
--- a/src/VatCalculator.php
+++ b/src/VatCalculator.php
@@ -271,11 +271,11 @@ class VatCalculator
             ],
         ],
         'RO' => [ // Romania
-            'rate' => 0.19,
+            'rate' => 0.21,
             'rates' => [
-                'high' => 0.19,
-                'low' => 0.05,
-                'low1' => 0.09,
+                'high' => 0.21,
+                'low' => 0.11,
+                'low1' => 0.09 // certain housing supplies will remain at the reduced rate of 9% during a transition period from August 2025 until 1 August 2026
             ],
         ],
         'SE' => [ // Sweden


### PR DESCRIPTION
According to law, certain housing products will remain at 9% from August 01 2025 to August 01 2026 @see https://mfinante.gov.ro/static/10/Mfp/transparenta/proiectLegemasurifiscale_03072025.pdf